### PR TITLE
OnPowerUse and AfterAttackRoll events

### DIFF
--- a/campaign/4e/char_power.xml
+++ b/campaign/4e/char_power.xml
@@ -1,51 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-  Please see the license.html file included with this distribution for 
-  attribution and copyright information.
+	Please see the license.html file included with this distribution for 
+	attribution and copyright information.
 -->
 
 <root>
-    <windowclass name="char_power" merge="join" ruleset="4E">
-		<script>
-            local fActivatePowerOriginal;
-            function onInit()
-                fActivatePowerOriginal = super.activatePower;
-                super.activatePower = activatePower;
-
-                if super and super.onInit then
-                    super.onInit()
-                end
-            end
-
-            function activatePower()
-                fActivatePowerOriginal();
-                local node = getDatabaseNode();
-
-                local charnode = node.getChild("...");
-                local rActor = ActorManager.resolveActor(charnode);
-
-                local sName = DB.getValue(node, "name", "");
-                local sRange = DB.getValue(node, "range", "");
-                local sRecharge = DB.getValue(node, "recharge", "");
-                local sAction = DB.getValue(node, "action", "");
-                local sKeywords = DB.getValue(node, "keywords", "");
-
-                local rPower = { 
-                    sName = sName, 
-                    sRange = sRange,
-                    sRecharge = sRecharge,
-                    sAction = sAction,
-                    sKeywords = sKeywords
-                };
-                local rEventData = {
-                    rSource = rActor,
-                    rPower = rPower
-                };
-                
-                TriggerManager.fireEvent(
-                    CharPowerTMT_4E.rPowerUsedEvent.sName, 
-                    rEventData);
-            end
-        </script>
+	<windowclass name="char_power" merge="join" ruleset="4E">
+		<script file="campaign/4e/scripts/char_power.lua" />
 	</windowclass> 
 </root>

--- a/campaign/4e/char_power.xml
+++ b/campaign/4e/char_power.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Please see the license.html file included with this distribution for 
+  attribution and copyright information.
+-->
+
+<root>
+    <windowclass name="char_power" merge="join" ruleset="4E">
+		<script>
+            local fActivatePowerOriginal;
+            function onInit()
+                fActivatePowerOriginal = super.activatePower;
+                super.activatePower = activatePower;
+
+                if super and super.onInit then
+                    super.onInit()
+                end
+            end
+
+            function activatePower()
+                fActivatePowerOriginal();
+                local node = getDatabaseNode();
+
+                local charnode = node.getChild("...");
+                local rActor = ActorManager.resolveActor(charnode);
+
+                local sName = DB.getValue(node, "name", "");
+                local sRange = DB.getValue(node, "range", "");
+                local sRecharge = DB.getValue(node, "recharge", "");
+                local sAction = DB.getValue(node, "action", "");
+                local sKeywords = DB.getValue(node, "keywords", "");
+
+                local rPower = { 
+                    sName = sName, 
+                    sRange = sRange,
+                    sRecharge = sRecharge,
+                    sAction = sAction,
+                    sKeywords = sKeywords
+                };
+                local rEventData = {
+                    rSource = rActor,
+                    rPower = rPower
+                };
+                
+                TriggerManager.fireEvent(
+                    CharPowerTMT_4E.rPowerUsedEvent.sName, 
+                    rEventData);
+            end
+        </script>
+	</windowclass> 
+</root>

--- a/campaign/4e/scripts/char_power.lua
+++ b/campaign/4e/scripts/char_power.lua
@@ -1,0 +1,39 @@
+local fActivatePowerOriginal;
+function onInit()
+	fActivatePowerOriginal = super.activatePower;
+	super.activatePower = activatePower;
+
+	if super and super.onInit then
+		super.onInit()
+	end
+end
+
+function activatePower()
+	fActivatePowerOriginal();
+	local node = getDatabaseNode();
+
+	local charnode = node.getChild("...");
+	local rActor = ActorManager.resolveActor(charnode);
+
+	local sName = DB.getValue(node, "name", "");
+	local sRange = DB.getValue(node, "range", "");
+	local sRecharge = DB.getValue(node, "recharge", "");
+	local sAction = DB.getValue(node, "action", "");
+	local sKeywords = DB.getValue(node, "keywords", "");
+
+	local rPower = { 
+		sName = sName, 
+		sRange = sRange,
+		sRecharge = sRecharge,
+		sAction = sAction,
+		sKeywords = sKeywords
+	};
+	local rEventData = {
+		rSource = rActor,
+		rPower = rPower
+	};
+	
+	TriggerManager.fireEvent(
+		CharPowerTMT_4E.rPowerUsedEvent.sName, 
+		rEventData);
+end

--- a/campaign/5e/record_power.xml
+++ b/campaign/5e/record_power.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Please see the license.html file included with this distribution for 
+  attribution and copyright information.
+-->
+
+<root>
+    <windowclass name="power_item" merge="join" ruleset="5E">
+        <script>
+            local fUsePowerOriginal;
+
+            function onInit()
+                fUsePowerOriginal = super.usePower;
+                super.usePower = usePower;
+
+                if super and super.onInit then
+                    super.onInit();
+                end
+            end
+
+            function usePower(bShowFull)
+                fUsePowerOriginal(bShowFull);
+                
+                local node = getDatabaseNode();
+
+                local charnode = node.getChild("...");
+                local rActor = ActorManager.resolveActor(charnode);
+
+                local sName = DB.getValue(node, "name", "");
+                local nLevel = DB.getValue(node, "level", 0);
+                local sSchool = DB.getValue(node, "school", "");
+                local sCastingTime = DB.getValue(node, "castingtime", "");
+                local sComponents = DB.getValue(node, "components", "");
+                local sDuration = DB.getValue(node, "duration", "");
+                local sGroup = DB.getValue(node, "group", "");
+                local sRange = DB.getValue(node, "range", "");
+
+                local rPower = { 
+                    sName = sName, 
+                    nLevel = nLevel,
+                    sSchool = sSchool,
+                    sCastingTime = sCastingTime,
+                    sComponents = sComponents,
+                    sDuration = sDuration,
+                    sGroup = sGroup,
+                    sRange = sRange
+                };
+                local rEventData = {
+                    rSource = rActor,
+                    rPower = rPower
+                };
+                
+                TriggerManager.fireEvent(
+                    CharDamageTMT_5E.rPowerUsedEvent.sName, 
+                    rEventData);
+            end
+        </script>
+    </windowclass>
+</root>

--- a/campaign/5e/record_power.xml
+++ b/campaign/5e/record_power.xml
@@ -1,59 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-  Please see the license.html file included with this distribution for 
-  attribution and copyright information.
+	Please see the license.html file included with this distribution for 
+	attribution and copyright information.
 -->
 
 <root>
-    <windowclass name="power_item" merge="join" ruleset="5E">
-        <script>
-            local fUsePowerOriginal;
-
-            function onInit()
-                fUsePowerOriginal = super.usePower;
-                super.usePower = usePower;
-
-                if super and super.onInit then
-                    super.onInit();
-                end
-            end
-
-            function usePower(bShowFull)
-                fUsePowerOriginal(bShowFull);
-                
-                local node = getDatabaseNode();
-
-                local charnode = node.getChild("...");
-                local rActor = ActorManager.resolveActor(charnode);
-
-                local sName = DB.getValue(node, "name", "");
-                local nLevel = DB.getValue(node, "level", 0);
-                local sSchool = DB.getValue(node, "school", "");
-                local sCastingTime = DB.getValue(node, "castingtime", "");
-                local sComponents = DB.getValue(node, "components", "");
-                local sDuration = DB.getValue(node, "duration", "");
-                local sGroup = DB.getValue(node, "group", "");
-                local sRange = DB.getValue(node, "range", "");
-
-                local rPower = { 
-                    sName = sName, 
-                    nLevel = nLevel,
-                    sSchool = sSchool,
-                    sCastingTime = sCastingTime,
-                    sComponents = sComponents,
-                    sDuration = sDuration,
-                    sGroup = sGroup,
-                    sRange = sRange
-                };
-                local rEventData = {
-                    rSource = rActor,
-                    rPower = rPower
-                };
-                
-                TriggerManager.fireEvent(
-                    CharDamageTMT_5E.rPowerUsedEvent.sName, 
-                    rEventData);
-            end
-        </script>
-    </windowclass>
+	<windowclass name="power_item" merge="join" ruleset="5E">
+		<script file="campaign/5e/scripts/record_power.lua" />
+	</windowclass>
 </root>

--- a/campaign/5e/scripts/record_power.lua
+++ b/campaign/5e/scripts/record_power.lua
@@ -1,0 +1,47 @@
+local fUsePowerOriginal;
+
+function onInit()
+	fUsePowerOriginal = super.usePower;
+	super.usePower = usePower;
+
+	if super and super.onInit then
+		super.onInit();
+	end
+end
+
+function usePower(bShowFull)
+	fUsePowerOriginal(bShowFull);
+	
+	local node = getDatabaseNode();
+
+	local charnode = node.getChild("...");
+	local rActor = ActorManager.resolveActor(charnode);
+
+	local sName = DB.getValue(node, "name", "");
+	local nLevel = DB.getValue(node, "level", 0);
+	local sSchool = DB.getValue(node, "school", "");
+	local sCastingTime = DB.getValue(node, "castingtime", "");
+	local sComponents = DB.getValue(node, "components", "");
+	local sDuration = DB.getValue(node, "duration", "");
+	local sGroup = DB.getValue(node, "group", "");
+	local sRange = DB.getValue(node, "range", "");
+
+	local rPower = { 
+		sName = sName, 
+		nLevel = nLevel,
+		sSchool = sSchool,
+		sCastingTime = sCastingTime,
+		sComponents = sComponents,
+		sDuration = sDuration,
+		sGroup = sGroup,
+		sRange = sRange
+	};
+	local rEventData = {
+		rSource = rActor,
+		rPower = rPower
+	};
+	
+	TriggerManager.fireEvent(
+		CharDamageTMT_5E.rPowerUsedEvent.sName, 
+		rEventData);
+end

--- a/extension.xml
+++ b/extension.xml
@@ -38,18 +38,25 @@ Wood Board Vectors by Vecteezy
 
 	<base>
 		<script name="ActionsManagerTMT" file="scripts/manager_actions_tmt.lua" />
-		<script name="ActionDamageTMT_5E" file="scripts/manager_action_damage_5e_tmt.lua" ruleset="5E" />
+		
 		<script name="CampaignDataManagerTMT" file="scripts/manager_campaigndata_tmt.lua" />
-		<script name="CharDamageTMT_5E" file="scripts/manager_char_5e_tmt.lua" ruleset="5E" />
 		<script name="DesktopManagerTMT" file="scripts/manager_desktop_tmt.lua" />
 		<script name="EffectManagerTMT" file="scripts/manager_effect_tmt.lua" />
+		<script name="ChatManagerTMT" file="scripts/manager_chat_tmt.lua" />
 		<script name="LibraryDataTMT" file="scripts/data_library_tmt.lua" />
 		<script name="TriggerData" file="scripts/data_trigger.lua" />
 		<script name="TriggerManager" file="scripts/manager_trigger.lua" />
 
+		<!-- 5E -->
+		<script name="CharDamageTMT_5E" file="scripts/manager_char_5e_tmt.lua" ruleset="5E" />
+		<script name="ActionDamageTMT_5E" file="scripts/manager_action_damage_5e_tmt.lua" ruleset="5E" />
+		<script name="ActionAttackTMT_5E" file="scripts/manager_action_attack_5e_tmt.lua" ruleset="5E" />
+		<includefile source="campaign/5e/record_power.xml" ruleset="5E" />
+
 		<!-- 4E -->
 		<script name="CharPowerTMT_4E" file="scripts/manager_char_4e_tmt.lua" ruleset="4E" />
 		<script name="ActionDamageTMT_4E" file="scripts/manager_action_damage_4e_tmt.lua" ruleset="4E" />
+		<script name="ActionAttackTMT_4E" file="scripts/manager_action_attack_4e_tmt.lua" ruleset="4E" />
 		<includefile source="campaign/4e/char_power.xml" ruleset="4E" />
 
 		<!-- TMT -->

--- a/extension.xml
+++ b/extension.xml
@@ -47,6 +47,12 @@ Wood Board Vectors by Vecteezy
 		<script name="TriggerData" file="scripts/data_trigger.lua" />
 		<script name="TriggerManager" file="scripts/manager_trigger.lua" />
 
+		<!-- 4E -->
+		<script name="CharPowerTMT_4E" file="scripts/manager_char_4e_tmt.lua" ruleset="4E" />
+		<script name="ActionDamageTMT_4E" file="scripts/manager_action_damage_4e_tmt.lua" ruleset="4E" />
+		<includefile source="campaign/4e/char_power.xml" ruleset="4E" />
+
+		<!-- TMT -->
 		<includefile source="triggers/triggers.xml" />
 		<includefile source="triggers/template_triggers.xml" />
 

--- a/scripts/manager_action_attack_4e_tmt.lua
+++ b/scripts/manager_action_attack_4e_tmt.lua
@@ -4,78 +4,78 @@
 --
 
 rAfterAttackRollEvent = {
-    sName = "after_attack_event",
-    aParameters = {
-        "rSource",
-        "rTarget",
-        "nAttack",
-        "sDesc",
-        "sResults"
-    }
+	sName = "after_attack_event",
+	aParameters = {
+		"rSource",
+		"rTarget",
+		"nAttack",
+		"sDesc",
+		"sResults"
+	}
 }
 rAttackResultCondition = nil;
 
 local fApplyAttackOriginal;
 
 function onInit()
-    fApplyAttackOriginal = ActionAttack.applyAttack;
-    ActionAttack.applyAttack = applyAttack;
+	fApplyAttackOriginal = ActionAttack.applyAttack;
+	ActionAttack.applyAttack = applyAttack;
 
-    initializeConditions();
-    TriggerManager.defineEvent(rAfterAttackRollEvent);
+	initializeConditions();
+	TriggerManager.defineEvent(rAfterAttackRollEvent);
 end
 
 function initializeConditions()
-    rAttackResultCondition = {
-        sName = "attack_result_condition",
-        fCondition = attackMatchesResultCondition,
-        aRequriedParameters = {
-            "rSource",
-            "rTarget",
-            "nAttack",
-            "sResults"
-        },
-        aConfigurableParameters = {
-            {
-                sName = "sAttackResult",
-                sDisplay = "attack_result_property_parameter",
-                sType = "combo",
-                aDefinedValues = {
-                    "attack_result_property_hit",
-                    "attack_result_property_miss",
-                    "attack_result_property_critical",
-                    "attack_result_property_fumble"
-                }
-            }
-        }
-    }
+	rAttackResultCondition = {
+		sName = "attack_result_condition",
+		fCondition = attackMatchesResultCondition,
+		aRequriedParameters = {
+			"rSource",
+			"rTarget",
+			"nAttack",
+			"sResults"
+		},
+		aConfigurableParameters = {
+			{
+				sName = "sAttackResult",
+				sDisplay = "attack_result_property_parameter",
+				sType = "combo",
+				aDefinedValues = {
+					"attack_result_property_hit",
+					"attack_result_property_miss",
+					"attack_result_property_critical",
+					"attack_result_property_fumble"
+				}
+			}
+		}
+	}
 
-    TriggerManager.defineCondition(rAttackResultCondition);
+	TriggerManager.defineCondition(rAttackResultCondition);
 end
 
 function attackMatchesResultCondition(rTriggerData, rEventData)
-    if rTriggerData.sAttackResult == "attack_result_property_hit" then
-        return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
-    elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
-        return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
-    elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
-        return string.match(rEventData.sResults, "%[MISS%]") ~= nil
-    elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
-        return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
-    end
+	if rTriggerData.sAttackResult == "attack_result_property_hit" then
+		return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
+	elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
+		return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
+	elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
+		return string.match(rEventData.sResults, "%[MISS%]") ~= nil
+	elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
+		return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
+	end
 
-    return false;
+	return false;
 end
 
 function applyAttack(rSource, rTarget, sDesc, nTotal, sResults, bSecret)
-    fApplyAttackOriginal(rSource, rTarget, sDesc, nTotal, sResults, bSecret);
+	fApplyAttackOriginal(rSource, rTarget, sDesc, nTotal, sResults, bSecret);
 
-    local rEventData = {
-        rSource = rSource,
-        rTarget = rTarget,
-        nAttack = nTotal,
-        sDesc = sDesc,
-        sResults = sResults
-    }
-    TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
+	local rEventData = {
+		rSource = rSource,
+		rTarget = rTarget,
+		nAttack = nTotal,
+		sDesc = sDesc,
+		sResults = sResults
+	}
+	TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
 end

--- a/scripts/manager_action_attack_4e_tmt.lua
+++ b/scripts/manager_action_attack_4e_tmt.lua
@@ -1,0 +1,81 @@
+-- 
+-- Please see the license.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+rAfterAttackRollEvent = {
+    sName = "after_attack_event",
+    aParameters = {
+        "rSource",
+        "rTarget",
+        "nAttack",
+        "sDesc",
+        "sResults"
+    }
+}
+rAttackResultCondition = nil;
+
+local fApplyAttackOriginal;
+
+function onInit()
+    fApplyAttackOriginal = ActionAttack.applyAttack;
+    ActionAttack.applyAttack = applyAttack;
+
+    initializeConditions();
+    TriggerManager.defineEvent(rAfterAttackRollEvent);
+end
+
+function initializeConditions()
+    rAttackResultCondition = {
+        sName = "attack_result_condition",
+        fCondition = attackMatchesResultCondition,
+        aRequriedParameters = {
+            "rSource",
+            "rTarget",
+            "nAttack",
+            "sResults"
+        },
+        aConfigurableParameters = {
+            {
+                sName = "sAttackResult",
+                sDisplay = "attack_result_property_parameter",
+                sType = "combo",
+                aDefinedValues = {
+                    "attack_result_property_hit",
+                    "attack_result_property_miss",
+                    "attack_result_property_critical",
+                    "attack_result_property_fumble"
+                }
+            }
+        }
+    }
+
+    TriggerManager.defineCondition(rAttackResultCondition);
+end
+
+function attackMatchesResultCondition(rTriggerData, rEventData)
+    if rTriggerData.sAttackResult == "attack_result_property_hit" then
+        return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
+    elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
+        return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
+    elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
+        return string.match(rEventData.sResults, "%[MISS%]") ~= nil
+    elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
+        return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
+    end
+
+    return false;
+end
+
+function applyAttack(rSource, rTarget, sDesc, nTotal, sResults, bSecret)
+    fApplyAttackOriginal(rSource, rTarget, sDesc, nTotal, sResults, bSecret);
+
+    local rEventData = {
+        rSource = rSource,
+        rTarget = rTarget,
+        nAttack = nTotal,
+        sDesc = sDesc,
+        sResults = sResults
+    }
+    TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
+end

--- a/scripts/manager_action_attack_5e_tmt.lua
+++ b/scripts/manager_action_attack_5e_tmt.lua
@@ -4,78 +4,78 @@
 --
 
 rAfterAttackRollEvent = {
-    sName = "after_attack_event",
-    aParameters = {
-        "rSource",
-        "rTarget",
-        "nAttack",
-        "sDesc",
-        "sResults"
-    }
+	sName = "after_attack_event",
+	aParameters = {
+		"rSource",
+		"rTarget",
+		"nAttack",
+		"sDesc",
+		"sResults"
+	}
 }
 rAttackResultCondition = nil;
 
 local fApplyAttackOriginal;
 
 function onInit()
-    fApplyAttackOriginal = ActionAttack.applyAttack;
-    ActionAttack.applyAttack = applyAttack;
+	fApplyAttackOriginal = ActionAttack.applyAttack;
+	ActionAttack.applyAttack = applyAttack;
 
-    initializeConditions();
-    TriggerManager.defineEvent(rAfterAttackRollEvent);
+	initializeConditions();
+	TriggerManager.defineEvent(rAfterAttackRollEvent);
 end
 
 function initializeConditions()
-    rAttackResultCondition = {
-        sName = "attack_result_condition",
-        fCondition = attackMatchesResultCondition,
-        aRequriedParameters = {
-            "rSource",
-            "rTarget",
-            "nAttack",
-            "sResults"
-        },
-        aConfigurableParameters = {
-            {
-                sName = "sAttackResult",
-                sDisplay = "attack_result_property_parameter",
-                sType = "combo",
-                aDefinedValues = {
-                    "attack_result_property_hit",
-                    "attack_result_property_miss",
-                    "attack_result_property_critical",
-                    "attack_result_property_fumble"
-                }
-            }
-        }
-    }
+	rAttackResultCondition = {
+		sName = "attack_result_condition",
+		fCondition = attackMatchesResultCondition,
+		aRequriedParameters = {
+			"rSource",
+			"rTarget",
+			"nAttack",
+			"sResults"
+		},
+		aConfigurableParameters = {
+			{
+				sName = "sAttackResult",
+				sDisplay = "attack_result_property_parameter",
+				sType = "combo",
+				aDefinedValues = {
+					"attack_result_property_hit",
+					"attack_result_property_miss",
+					"attack_result_property_critical",
+					"attack_result_property_fumble"
+				}
+			}
+		}
+	}
 
-    TriggerManager.defineCondition(rAttackResultCondition);
+	TriggerManager.defineCondition(rAttackResultCondition);
 end
 
 function attackMatchesResultCondition(rTriggerData, rEventData)
-    if rTriggerData.sAttackResult == "attack_result_property_hit" then
-        return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
-    elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
-        return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
-    elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
-        return string.match(rEventData.sResults, "%[MISS%]") ~= nil
-    elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
-        return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
-    end
+	if rTriggerData.sAttackResult == "attack_result_property_hit" then
+		return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
+	elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
+		return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
+	elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
+		return string.match(rEventData.sResults, "%[MISS%]") ~= nil
+	elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
+		return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
+	end
 
-    return false;
+	return false;
 end
 
 function applyAttack(rSource, rTarget, bSecret, sAttackType, sDesc, nTotal, sResults)
-    fApplyAttackOriginal(rSource, rTarget, bSecret, sAttackType, sDesc, nTotal, sResults);
+	fApplyAttackOriginal(rSource, rTarget, bSecret, sAttackType, sDesc, nTotal, sResults);
 
-    local rEventData = {
-        rSource = rSource,
-        rTarget = rTarget,
-        nAttack = nTotal,
-        sDesc = sDesc,
-        sResults = sResults
-    }
-    TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
+	local rEventData = {
+		rSource = rSource,
+		rTarget = rTarget,
+		nAttack = nTotal,
+		sDesc = sDesc,
+		sResults = sResults
+	}
+	TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
 end

--- a/scripts/manager_action_attack_5e_tmt.lua
+++ b/scripts/manager_action_attack_5e_tmt.lua
@@ -1,0 +1,81 @@
+-- 
+-- Please see the license.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+rAfterAttackRollEvent = {
+    sName = "after_attack_event",
+    aParameters = {
+        "rSource",
+        "rTarget",
+        "nAttack",
+        "sDesc",
+        "sResults"
+    }
+}
+rAttackResultCondition = nil;
+
+local fApplyAttackOriginal;
+
+function onInit()
+    fApplyAttackOriginal = ActionAttack.applyAttack;
+    ActionAttack.applyAttack = applyAttack;
+
+    initializeConditions();
+    TriggerManager.defineEvent(rAfterAttackRollEvent);
+end
+
+function initializeConditions()
+    rAttackResultCondition = {
+        sName = "attack_result_condition",
+        fCondition = attackMatchesResultCondition,
+        aRequriedParameters = {
+            "rSource",
+            "rTarget",
+            "nAttack",
+            "sResults"
+        },
+        aConfigurableParameters = {
+            {
+                sName = "sAttackResult",
+                sDisplay = "attack_result_property_parameter",
+                sType = "combo",
+                aDefinedValues = {
+                    "attack_result_property_hit",
+                    "attack_result_property_miss",
+                    "attack_result_property_critical",
+                    "attack_result_property_fumble"
+                }
+            }
+        }
+    }
+
+    TriggerManager.defineCondition(rAttackResultCondition);
+end
+
+function attackMatchesResultCondition(rTriggerData, rEventData)
+    if rTriggerData.sAttackResult == "attack_result_property_hit" then
+        return string.match(rEventData.sResults, "%[HIT%]") ~= nil or string.match(rEventData.sResults, "%[AUTOMATIC HIT%]") ~= nil;
+    elseif rTriggerData.sAttackResult == "attack_result_property_critical" then
+        return string.match(rEventData.sResults, "%[CRITICAL HIT%]") ~= nil;
+    elseif rTriggerData.sAttackResult == "attack_result_property_miss" then
+        return string.match(rEventData.sResults, "%[MISS%]") ~= nil
+    elseif rTriggerData.sAttackResult == "attack_result_property_fumble" then
+        return string.match(rEventData.sResults, "%[AUTOMATIC MISS%]") ~= nil or string.match(rEventData.sResults, "%[FUMBLE%]") ~= nil
+    end
+
+    return false;
+end
+
+function applyAttack(rSource, rTarget, bSecret, sAttackType, sDesc, nTotal, sResults)
+    fApplyAttackOriginal(rSource, rTarget, bSecret, sAttackType, sDesc, nTotal, sResults);
+
+    local rEventData = {
+        rSource = rSource,
+        rTarget = rTarget,
+        nAttack = nTotal,
+        sDesc = sDesc,
+        sResults = sResults
+    }
+    TriggerManager.fireEvent(rAfterAttackRollEvent.sName, rEventData);
+end

--- a/scripts/manager_action_damage_4e_tmt.lua
+++ b/scripts/manager_action_damage_4e_tmt.lua
@@ -6,17 +6,17 @@
 rApplyHpCombatantAction = nil;
 
 function onInit()
-    initializeActions();
+	initializeActions();
 end
 
 function initializeActions()
-    -- TODO: Add more parameters to this action
-    -- For spending healing surges, maybe adding dice instead of a flat value
-    rApplyHpCombatantAction = {
-        sName = "apply_heal_to_combatant_action",
-        fAction = applyHpToCombatant,
-        aConfigurableParameters = {
-            {
+	-- TODO: Add more parameters to this action
+	-- For spending healing surges, maybe adding dice instead of a flat value
+	rApplyHpCombatantAction = {
+		sName = "apply_heal_to_combatant_action",
+		fAction = applyHpToCombatant,
+		aConfigurableParameters = {
+			{
 				sName = "sCombatant",
 				sDisplay = "combatant_parameter",
 				sType = "combo",
@@ -31,60 +31,60 @@ function initializeActions()
 					},
 				}
 			},
-            {
-                sName = "sLabel",
-                sDisplay = "apply_heal_label_parameter",
-                sType = "string"
-            },
-            {
-                sName = "sType",
-                sDisplay = "apply_heal_type_parameter",
-                sType = "combo",
-                aDefinedValues = {
-                    "apply_heal_type_hitpoints",
-                    "apply_heal_type_temphitpoints"
-                }
-            },
-            {
-                sName = "nValue",
-                sDisplay = "apply_heal_value_parameter",
-                sType = "number"
-            }
-        }
-    }
+			{
+				sName = "sLabel",
+				sDisplay = "apply_heal_label_parameter",
+				sType = "string"
+			},
+			{
+				sName = "sType",
+				sDisplay = "apply_heal_type_parameter",
+				sType = "combo",
+				aDefinedValues = {
+					"apply_heal_type_hitpoints",
+					"apply_heal_type_temphitpoints"
+				}
+			},
+			{
+				sName = "nValue",
+				sDisplay = "apply_heal_value_parameter",
+				sType = "number"
+			}
+		}
+	}
 
-    TriggerManager.defineAction(rApplyHpCombatantAction);
+	TriggerManager.defineAction(rApplyHpCombatantAction);
 end
 
 function applyHpToCombatant(rTriggerData, rEventData)
-    local rActor = nil;
-    if rTriggerData.sCombatant == "source_subject" then
+	local rActor = nil;
+	if rTriggerData.sCombatant == "source_subject" then
 		rActor = rEventData.rSource;
 	elseif rTriggerData.sCombatant == "target_subject" then
 		rActor = rEventData.rTarget;
 	end
 
-    local rAction = {};
-    rAction.type = "heal";
-    rAction.name = rTriggerData.sLabel or "";
-    rAction.order = 0;
-    rAction.range = "";
-    rAction.sTargeting = "self";
-    rAction.clauses = {};
+	local rAction = {};
+	rAction.type = "heal";
+	rAction.name = rTriggerData.sLabel or "";
+	rAction.order = 0;
+	rAction.range = "";
+	rAction.sTargeting = "self";
+	rAction.clauses = {};
 
-    local rHealClause = {};
-    rHealClause.dicestr = "" .. rTriggerData.nValue;
-    rHealClause.cost = 0;
-    rHealClause.basemult = 0;
-    rHealClause.stat = {};
+	local rHealClause = {};
+	rHealClause.dicestr = "" .. rTriggerData.nValue;
+	rHealClause.cost = 0;
+	rHealClause.basemult = 0;
+	rHealClause.stat = {};
 
-    if rTriggerData.sType == "apply_heal_type_hitpoints" then
-        rHealClause.subtype = "";
-    elseif rTriggerData.sType == "apply_heal_type_temphitpoints" then
-        rHealClause.subtype = "temp";
-    end
+	if rTriggerData.sType == "apply_heal_type_hitpoints" then
+		rHealClause.subtype = "";
+	elseif rTriggerData.sType == "apply_heal_type_temphitpoints" then
+		rHealClause.subtype = "temp";
+	end
 
-    table.insert(rAction.clauses, rHealClause);
-    
-    ActionHeal.performRoll(nil, rActor, rAction)
+	table.insert(rAction.clauses, rHealClause);
+	
+	ActionHeal.performRoll(nil, rActor, rAction)
 end

--- a/scripts/manager_action_damage_4e_tmt.lua
+++ b/scripts/manager_action_damage_4e_tmt.lua
@@ -1,0 +1,90 @@
+-- 
+-- Please see the license.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+rApplyHpCombatantAction = nil;
+
+function onInit()
+    initializeActions();
+end
+
+function initializeActions()
+    -- TODO: Add more parameters to this action
+    -- For spending healing surges, maybe adding dice instead of a flat value
+    rApplyHpCombatantAction = {
+        sName = "apply_heal_to_combatant_action",
+        fAction = applyHpToCombatant,
+        aConfigurableParameters = {
+            {
+				sName = "sCombatant",
+				sDisplay = "combatant_parameter",
+				sType = "combo",
+				aDefinedValues = {
+					{
+						sValue = "source_subject",
+						aRequiredParameters = {"rSource"}
+					},
+					{
+						sValue = "target_subject",
+						aRequiredParameters = {"rTarget"}
+					},
+				}
+			},
+            {
+                sName = "sLabel",
+                sDisplay = "apply_heal_label_parameter",
+                sType = "string"
+            },
+            {
+                sName = "sType",
+                sDisplay = "apply_heal_type_parameter",
+                sType = "combo",
+                aDefinedValues = {
+                    "apply_heal_type_hitpoints",
+                    "apply_heal_type_temphitpoints"
+                }
+            },
+            {
+                sName = "nValue",
+                sDisplay = "apply_heal_value_parameter",
+                sType = "number"
+            }
+        }
+    }
+
+    TriggerManager.defineAction(rApplyHpCombatantAction);
+end
+
+function applyHpToCombatant(rTriggerData, rEventData)
+    local rActor = nil;
+    if rTriggerData.sCombatant == "source_subject" then
+		rActor = rEventData.rSource;
+	elseif rTriggerData.sCombatant == "target_subject" then
+		rActor = rEventData.rTarget;
+	end
+
+    local rAction = {};
+    rAction.type = "heal";
+    rAction.name = rTriggerData.sLabel or "";
+    rAction.order = 0;
+    rAction.range = "";
+    rAction.sTargeting = "self";
+    rAction.clauses = {};
+
+    local rHealClause = {};
+    rHealClause.dicestr = "" .. rTriggerData.nValue;
+    rHealClause.cost = 0;
+    rHealClause.basemult = 0;
+    rHealClause.stat = {};
+
+    if rTriggerData.sType == "apply_heal_type_hitpoints" then
+        rHealClause.subtype = "";
+    elseif rTriggerData.sType == "apply_heal_type_temphitpoints" then
+        rHealClause.subtype = "temp";
+    end
+
+    table.insert(rAction.clauses, rHealClause);
+    
+    ActionHeal.performRoll(nil, rActor, rAction)
+end

--- a/scripts/manager_char_4e_tmt.lua
+++ b/scripts/manager_char_4e_tmt.lua
@@ -1,0 +1,74 @@
+-- 
+-- Please see the license.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+rPowerUsedCondition = nil;
+rPowerUsedEvent = {
+    sName = "power_used_event",
+    aParameters = { 
+        "rSource",
+        "rPower"
+    };
+};
+
+function onInit()
+    TriggerManager.defineEvent(rPowerUsedEvent);
+    initializeConditions();
+end
+
+function initializeConditions()
+    rPowerUsedCondition = {
+        sName = "power_used_contains_data",
+        fCondition  = powerContainsDataCondition,
+        aRequiredParameters = {
+            "rSource",
+            "rPower"
+        },
+        aConfigurableParameters = {
+            {
+                sName = "sPowerProperty",
+                sDisplay = "power_used_property_parameter",
+                sType = "combo",
+                aDefinedValues = {
+                    "power_used_property_name",
+                    "power_used_property_keywords",
+                    "power_used_property_recharge",
+                    "power_used_property_action",
+                    "power_used_property_range",
+                }
+            },
+            {
+                sName = "sPowerContains",
+                sDisplay = "power_used_contains_parameter",
+                sType = "string"
+            }
+        }
+    }
+
+    TriggerManager.defineCondition(rPowerUsedCondition)
+end
+
+function powerContainsDataCondition(rTriggerData, rEventData)
+    -- If contain property is empty, return true
+    if (rTriggerData.sPowerContains or "") == "" then
+        return true;
+    end
+
+    local sData = "";
+    if rTriggerData.sPowerProperty == "power_used_property_name" then
+        sData = rEventData.rPower.sName;
+    elseif rTriggerData.sPowerProperty == "power_used_property_keywords" then
+        sData = rEventData.rPower.sKeywords;
+    elseif rTriggerData.sPowerProperty == "power_used_property_recharge" then
+        sData = rEventData.rPower.sRecharge;
+    elseif rTriggerData.sPowerProperty == "power_used_property_action" then
+        sData = rEventData.rPower.sAction;
+    elseif rTriggerData.sPowerProperty == "power_used_property_range" then
+        sData = rEventData.rPower.sRange;
+    end
+    if string.find(sData:lower(), rTriggerData.sPowerContains:lower()) then
+        return true;
+    end
+    return false;
+end

--- a/scripts/manager_char_4e_tmt.lua
+++ b/scripts/manager_char_4e_tmt.lua
@@ -3,7 +3,7 @@
 -- attribution and copyright information.
 --
 
-rPowerUsedCondition = nil;
+rPowerContainsDataCondition = nil;
 rPowerUsedEvent = {
     sName = "power_used_event",
     aParameters = { 
@@ -18,7 +18,7 @@ function onInit()
 end
 
 function initializeConditions()
-    rPowerUsedCondition = {
+    rPowerContainsDataCondition = {
         sName = "power_used_contains_data",
         fCondition  = powerContainsDataCondition,
         aRequiredParameters = {
@@ -46,7 +46,7 @@ function initializeConditions()
         }
     }
 
-    TriggerManager.defineCondition(rPowerUsedCondition)
+    TriggerManager.defineCondition(rPowerContainsDataCondition);
 end
 
 function powerContainsDataCondition(rTriggerData, rEventData)

--- a/scripts/manager_char_4e_tmt.lua
+++ b/scripts/manager_char_4e_tmt.lua
@@ -5,70 +5,65 @@
 
 rPowerContainsDataCondition = nil;
 rPowerUsedEvent = {
-    sName = "power_used_event",
-    aParameters = { 
-        "rSource",
-        "rPower"
-    };
+	sName = "power_used_event",
+	aParameters = { 
+		"rSource",
+		"rPower"
+	};
 };
 
 function onInit()
-    TriggerManager.defineEvent(rPowerUsedEvent);
-    initializeConditions();
+	TriggerManager.defineEvent(rPowerUsedEvent);
+	initializeConditions();
 end
 
 function initializeConditions()
-    rPowerContainsDataCondition = {
-        sName = "power_used_contains_data",
-        fCondition  = powerContainsDataCondition,
-        aRequiredParameters = {
-            "rSource",
-            "rPower"
-        },
-        aConfigurableParameters = {
-            {
-                sName = "sPowerProperty",
-                sDisplay = "power_used_property_parameter",
-                sType = "combo",
-                aDefinedValues = {
-                    "power_used_property_name",
-                    "power_used_property_keywords",
-                    "power_used_property_recharge",
-                    "power_used_property_action",
-                    "power_used_property_range",
-                }
-            },
-            {
-                sName = "sPowerContains",
-                sDisplay = "power_used_contains_parameter",
-                sType = "string"
-            }
-        }
-    }
+	rPowerContainsDataCondition = {
+		sName = "power_used_contains_data",
+		fCondition  = powerContainsDataCondition,
+		aRequiredParameters = {
+			"rSource",
+			"rPower"
+		},
+		aConfigurableParameters = {
+			{
+				sName = "sPowerProperty",
+				sDisplay = "power_used_property_parameter",
+				sType = "combo",
+				aDefinedValues = {
+					"power_used_property_name",
+					"power_used_property_keywords",
+					"power_used_property_recharge",
+					"power_used_property_action",
+					"power_used_property_range",
+				}
+			},
+			{
+				sName = "sPowerContains",
+				sDisplay = "power_used_contains_parameter",
+				sType = "string"
+			}
+		}
+	}
 
-    TriggerManager.defineCondition(rPowerContainsDataCondition);
+	TriggerManager.defineCondition(rPowerContainsDataCondition);
 end
 
 function powerContainsDataCondition(rTriggerData, rEventData)
-    -- If contain property is empty, return true
-    if (rTriggerData.sPowerContains or "") == "" then
-        return true;
-    end
-
-    local sData = "";
-    if rTriggerData.sPowerProperty == "power_used_property_name" then
-        sData = rEventData.rPower.sName;
-    elseif rTriggerData.sPowerProperty == "power_used_property_keywords" then
-        sData = rEventData.rPower.sKeywords;
-    elseif rTriggerData.sPowerProperty == "power_used_property_recharge" then
-        sData = rEventData.rPower.sRecharge;
-    elseif rTriggerData.sPowerProperty == "power_used_property_action" then
-        sData = rEventData.rPower.sAction;
-    elseif rTriggerData.sPowerProperty == "power_used_property_range" then
-        sData = rEventData.rPower.sRange;
-    end
-    if string.find(sData:lower(), rTriggerData.sPowerContains:lower()) then
-        return true;
-    end
-    return false;
+	local sData = "";
+	if rTriggerData.sPowerProperty == "power_used_property_name" then
+		sData = rEventData.rPower.sName;
+	elseif rTriggerData.sPowerProperty == "power_used_property_keywords" then
+		sData = rEventData.rPower.sKeywords;
+	elseif rTriggerData.sPowerProperty == "power_used_property_recharge" then
+		sData = rEventData.rPower.sRecharge;
+	elseif rTriggerData.sPowerProperty == "power_used_property_action" then
+		sData = rEventData.rPower.sAction;
+	elseif rTriggerData.sPowerProperty == "power_used_property_range" then
+		sData = rEventData.rPower.sRange;
+	end
+	if string.find(sData:lower(), rTriggerData.sPowerContains:lower()) then
+		return true;
+	end
+	return false;
 end

--- a/scripts/manager_char_5e_tmt.lua
+++ b/scripts/manager_char_5e_tmt.lua
@@ -4,8 +4,19 @@
 --
 
 rCreatureHasTraitCondition = nil;
+rPowerContainsDataCondition = nil;
+
+rPowerUsedEvent = {
+    sName = "power_used_event",
+    aParameters = { 
+        "rSource",
+        "rPower"
+    };
+};
 
 function onInit()
+	TriggerManager.defineEvent(rPowerUsedEvent);
+
 	initializeConditions();
 end
 
@@ -50,6 +61,39 @@ function initializeConditions()
 	};
 
 	TriggerManager.defineCondition(rCreatureHasTraitCondition);
+
+	rPowerContainsDataCondition = {
+        sName = "power_used_contains_data",
+        fCondition  = powerContainsDataCondition,
+        aRequiredParameters = {
+            "rSource",
+            "rPower"
+        },
+        aConfigurableParameters = {
+            {
+                sName = "sPowerProperty",
+                sDisplay = "power_used_property_parameter",
+                sType = "combo",
+                aDefinedValues = {
+                    "power_used_property_name",
+                    "power_used_property_level",
+                    "power_used_property_school",
+                    "power_used_property_castingtime",
+					"power_used_property_components",
+					"power_used_property_duration",
+					"power_used_property_group",
+                    "power_used_property_range",
+                }
+            },
+            {
+                sName = "sPowerContains",
+                sDisplay = "power_used_contains_parameter",
+                sType = "string"
+            }
+        }
+    }
+
+    TriggerManager.defineCondition(rPowerContainsDataCondition);
 end
 
 function creatureHasTraitCondition(rTriggerData, rEventData)
@@ -89,4 +133,35 @@ function hasTrait(rActor, sTrait)
 		end
 		return false;
 	end
+end
+
+function powerContainsDataCondition(rTriggerData, rEventData)
+    -- If contain property is empty, return true
+    if (rTriggerData.sPowerContains or "") == "" then
+        return true;
+    end
+
+    local sData = "";
+    if rTriggerData.sPowerProperty == "power_used_property_name" then
+        sData = rEventData.rPower.sName;
+    elseif rTriggerData.sPowerProperty == "power_used_property_level" then
+        sData = tostring(rEventData.rPower.nLevel);
+    elseif rTriggerData.sPowerProperty == "power_used_property_school" then
+        sData = rEventData.rPower.sSchool;
+    elseif rTriggerData.sPowerProperty == "power_used_property_castingtime" then
+        sData = rEventData.rPower.sCastingTime;
+	elseif rTriggerData.sPowerProperty == "power_used_property_components" then
+		sData = rEventData.rPower.sComponents;
+	elseif rTriggerData.sPowerProperty == "power_used_property_duration" then
+		sData = rEventData.rPower.sDuration;
+	elseif rTriggerData.sPowerProperty == "power_used_property_group" then
+		sData = rEventData.rPower.sGroup;
+    elseif rTriggerData.sPowerProperty == "power_used_property_range" then
+        sData = rEventData.rPower.sRange;
+    end
+    if string.find(sData:lower(), rTriggerData.sPowerContains:lower()) then
+        return true;
+    end
+
+    return false;
 end

--- a/scripts/manager_chat_tmt.lua
+++ b/scripts/manager_chat_tmt.lua
@@ -6,31 +6,31 @@
 rSendChatMessageAction = nil;
 
 function onInit()
-    initializeActions();
+	initializeActions();
 end
 
 function initializeActions()
-    rSendChatMessageAction = {
-        sName = "send_chat_message_action",
-        fAction = sendChatMessage,
-        aConfigurableParameters = {
-            {
-                sName = "sMessage",
-                sDisplay = "chat_message_parameter",
-                sType = "string"   
-            }
-        }
-    }
+	rSendChatMessageAction = {
+		sName = "send_chat_message_action",
+		fAction = sendChatMessage,
+		aConfigurableParameters = {
+			{
+				sName = "sMessage",
+				sDisplay = "chat_message_parameter",
+				sType = "string"   
+			}
+		}
+	}
 
-    TriggerManager.defineAction(rSendChatMessageAction);
+	TriggerManager.defineAction(rSendChatMessageAction);
 end
 
 function sendChatMessage(rTriggerData, rEventData)
-    local msg = {
-        sender = "",
-        font = "msgfont",
-        text = rTriggerData.sMessage,
-        icon = "TriggerMeTimbers"
-    }
-    Comm.deliverChatMessage(msg);
+	local msg = {
+		sender = "",
+		font = "msgfont",
+		text = rTriggerData.sMessage,
+		icon = "TriggerMeTimbers"
+	}
+	Comm.deliverChatMessage(msg);
 end

--- a/scripts/manager_chat_tmt.lua
+++ b/scripts/manager_chat_tmt.lua
@@ -1,0 +1,36 @@
+-- 
+-- Please see the license.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+rSendChatMessageAction = nil;
+
+function onInit()
+    initializeActions();
+end
+
+function initializeActions()
+    rSendChatMessageAction = {
+        sName = "send_chat_message_action",
+        fAction = sendChatMessage,
+        aConfigurableParameters = {
+            {
+                sName = "sMessage",
+                sDisplay = "chat_message_parameter",
+                sType = "string"   
+            }
+        }
+    }
+
+    TriggerManager.defineAction(rSendChatMessageAction);
+end
+
+function sendChatMessage(rTriggerData, rEventData)
+    local msg = {
+        sender = "",
+        font = "msgfont",
+        text = rTriggerData.sMessage,
+        icon = "TriggerMeTimbers"
+    }
+    Comm.deliverChatMessage(msg);
+end

--- a/strings/strings.xml
+++ b/strings/strings.xml
@@ -21,6 +21,7 @@
 
 	<string name="before_damage_taken_event">Before Damage Taken</string>
 	<string name="dice_rolled_event">Dice Rolled</string>
+	<string name="power_used_event">Power Used</string>
 
 	<string name="combatant_has_effect_condition">Combatant Has Effect</string>
 	<string name="creature_has_trait_condition">Creature Has Trait</string>
@@ -68,6 +69,22 @@
 	<string name="lowest_dice">Lowest</string>
 	<string name="matching_dice">Matching</string>
 	<string name="sum_dice">Sum</string>
+	
+	<string name="power_used_contains_data">Power Contains Data</string>
+	<string name="power_used_property_parameter">Property</string>
+	<string name="power_used_contains_parameter">Contains</string>
+	<string name="power_used_property_name">Name</string>
+	<string name="power_used_property_keywords">Keywords</string>
+	<string name="power_used_property_recharge">Recharge</string>
+	<string name="power_used_property_action">Action</string>
+	<string name="power_used_property_range">Range</string>
+
+	<string name="apply_heal_to_combatant_action">Apply Healing to Combatant</string>
+	<string name="apply_heal_label_parameter">Label</string>
+	<string name="apply_heal_type_parameter">Healing Type</string>
+	<string name="apply_heal_value_parameter">Value</string>
+	<string name="apply_heal_type_hitpoints">HP</string>
+	<string name="apply_heal_type_temphitpoints">Temp HP</string>
 
 	<string name="trait_type_all">All</string>
 	<string name="trait_type_feat">Feat</string>

--- a/strings/strings.xml
+++ b/strings/strings.xml
@@ -22,6 +22,7 @@
 	<string name="before_damage_taken_event">Before Damage Taken</string>
 	<string name="dice_rolled_event">Dice Rolled</string>
 	<string name="power_used_event">Power Used</string>
+	<string name="after_attack_event">After Attack Roll</string>
 
 	<string name="combatant_has_effect_condition">Combatant Has Effect</string>
 	<string name="creature_has_trait_condition">Creature Has Trait</string>
@@ -33,11 +34,14 @@
 	<string name="target_has_current_hit_points_condition">Target Has Current Hit Points</string>
 	<string name="combatant_has_temporary_hit_points_condition">Combatant Has Temporary Hit Points</string>
 
+	<!-- Actions -->
 	<string name="ensure_target_has_remaining_hit_points_action">Ensure Target Has Remaining Hit Points</string>
 	<string name="remove_effect_from_combatant_action">Remove Effect From Combatant</string>
 	<string name="replace_dice_action">Replace Dice</string>
 	<string name="reroll_dice_action">Reroll Dice</string>
+	<string name="send_chat_message_action">Send Chat Message</string>
 
+	<!-- Parameters -->
 	<string name="chat_message_parameter">Chat Message</string>
 	<string name="combatant_parameter">Combatant</string>
 	<string name="comparison_parameter">Comparison</string>
@@ -70,6 +74,7 @@
 	<string name="matching_dice">Matching</string>
 	<string name="sum_dice">Sum</string>
 	
+	<!-- Power contains data condition -->
 	<string name="power_used_contains_data">Power Contains Data</string>
 	<string name="power_used_property_parameter">Property</string>
 	<string name="power_used_contains_parameter">Contains</string>
@@ -78,7 +83,22 @@
 	<string name="power_used_property_recharge">Recharge</string>
 	<string name="power_used_property_action">Action</string>
 	<string name="power_used_property_range">Range</string>
+	<string name="power_used_property_level">Level</string>
+	<string name="power_used_property_school">School</string>
+	<string name="power_used_property_castingtime">Casting Time</string>
+	<string name="power_used_property_components">Components</string>
+	<string name="power_used_property_duration">Duration</string>
+	<string name="power_used_property_group">Group</string>
 
+	<!-- Attack result condition -->
+	<string name="attack_result_condition">Attack Roll Is Result</string>
+	<string name="attack_result_property_parameter">Result</string>
+	<string name="attack_result_property_hit">Hit</string>
+	<string name="attack_result_property_miss">Miss</string>
+	<string name="attack_result_property_critical">Critical Hit</string>
+	<string name="attack_result_property_fumble">Automatic Miss</string>
+
+	<!-- Apply healing action -->
 	<string name="apply_heal_to_combatant_action">Apply Healing to Combatant</string>
 	<string name="apply_heal_label_parameter">Label</string>
 	<string name="apply_heal_type_parameter">Healing Type</string>

--- a/triggers/scripts/parametercombobox.lua
+++ b/triggers/scripts/parametercombobox.lua
@@ -23,7 +23,7 @@ function configure(rParameterInfo, aEventParameters)
 			end
 		end
 	end
-	Debug.chat("configure", rParameterInfo, aEventParameters, node.getValue());
+	-- Debug.chat("configure", rParameterInfo, aEventParameters, node.getValue());
 	setComboValue(node.getValue());
 end
 


### PR DESCRIPTION
Added two new events:
* OnPowerUse, which fires when a power on the PC actions tab is checked off
* AfterAttackRoll, which fires after an attack is rolled and the result is printed to chat

Added new conditions
* PowerContainsData, which lets you check the data of a power that's used in the OnPowerUse event
* AttackResultCondition, which lets you check if an attack roll is a hit, miss, critical hit, or fumble

Added new actions
* SendChatMessage, which prints a message to chat

Added compatibility for D&D 4e. Added a new action for 4e only that adds hp (normal or temp)